### PR TITLE
Simplify lancie-dialog

### DIFF
--- a/lancie-dialog.html
+++ b/lancie-dialog.html
@@ -1,6 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-media-query/iron-media-query.html">
-
 
 <!--
 `lancie-dialog`
@@ -33,47 +31,41 @@ simply give it the `dialog-dismiss` attribute.
 <dom-module id="lancie-dialog">
   <template>
     <style>
-      #actualDialog {
+      :host {
         display: none;
         position: fixed;
-        width: 400px;
         left: 0;
         right: 0;
-        top: 43px;
-        margin: auto;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+        height: 100%;
         z-index: 11;
-
-        background-color: white;
-
-        @apply --lancie-dialog;
+        align-items: center;
+        justify-content: center;
       }
 
-      #actualDialog ::slotted(*) h2 {
+      #actualDialog {
+        display: none;
+        background-color: white;
+        z-index: 11;
+        position: fixed;
+        flex-direction: column;
+
+        @apply --lancie-actual-dialog
+      }
+
+      #actualDialog ::slotted(h2) {
         background-color: var(--primary-color);
         color: var(--secondary-color);
         margin: 0;
         font-size: 24px;
         font-weight: 400;
-      }
-
-      #actualDialog ::slotted(.dialog-header) {
-        background-color: var(--primary-color);
-        display: flex;
-        justify-content: space-between;
-      }
-
-      #actualDialog ::slotted(*) > h2 {
-        margin-left: 10px;
-        color: var(--secondary-color);
-      }
-
-      #actualDialog ::slotted(h2),
-      #actualDialog ::slotted(.dialog-content) {
         padding: 16px;
       }
 
       #actualDialog ::slotted(.dialog-content) {
-        background-color: white;
+        padding: 16px;
       }
 
       #actualDialog ::slotted(.dialog-actions) {
@@ -97,29 +89,7 @@ simply give it the `dialog-dismiss` attribute.
         z-index: 10;
         transition: opacity 0.1s linear;
       }
-      /* dialog width + (2 * margin) */
-
-      @media (max-width: 432px) {
-        #actualDialog {
-          width: calc(100% - 2 * 16px);
-          width: var(--lancie-dialog-width);
-          margin: 16px;
-          margin: var(--lancie-dialog-margin);
-        }
-      }
-
-      @media (max-height: 213px) {
-        #actualDialog {
-          top: var(--app-toolbar-height);
-        }
-      }
     </style>
-
-    <iron-media-query query="(max-width:432px)" query-matches="{{mobile}}"></iron-media-query>
-    <iron-media-query query="(max-width:600px)" query-matches="{{small}}"></iron-media-query>
-    <iron-media-query query="(max-width:800px)" query-matches="{{medium}}"></iron-media-query>
-    <iron-media-query query="(max-height:213px)" query-matches="{{short}}"></iron-media-query>
-    <iron-media-query query="(max-height:640px)" query-matches="{{long}}"></iron-media-query>
 
     <div id="actualDialog">
       <slot></slot>
@@ -134,15 +104,6 @@ simply give it the `dialog-dismiss` attribute.
     (function () {
       Polymer({
         is: 'lancie-dialog',
-
-        observers: [
-          '_viewChanged(mobile)',
-          '_viewChanged(small)',
-          '_viewChanged(medium)',
-          '_viewChanged(wide)',
-          '_viewChanged(short)',
-          '_viewChanged(long)'
-        ],
 
         ready: function () {
           this.addDismissListeners();
@@ -163,7 +124,8 @@ simply give it the `dialog-dismiss` attribute.
          * @return {void}
          */
         open: function () {
-          this.$.actualDialog.style.display = 'block';
+          this.style.display = 'flex';
+          this.$.actualDialog.style.display = 'flex';
           this.$.backdrop.style.display = 'block';
           this.async(function () {
             this.$.backdrop.style.opacity = '0.6';
@@ -176,15 +138,12 @@ simply give it the `dialog-dismiss` attribute.
         */
         close: function () {
           setTimeout(function () {
+          this.style.display = 'none';
             this.$.actualDialog.style.display = 'none';
             this.$.backdrop.style.display = 'none';
             this.$.backdrop.style.opacity = '0.0';
           }.bind(this), 130);
         },
-
-        _viewChanged: function () {
-          this.updateStyles();
-        }
       });
     })();
   </script>


### PR DESCRIPTION
The `lancie-dialog` was so ridicilously complicated that it didn't make sense at all. It fucked up styling over several pages and was simply unreadable. This is the first step of simplification by just using a more logical composition of the element to ease alignment and sizing.